### PR TITLE
Header references for visual decluttering

### DIFF
--- a/app/views/acute_rehab1_years/edit.html.slim
+++ b/app/views/acute_rehab1_years/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Editing acute_rehab1_year
-
+<hr>
 == render 'form'
 
 = link_to 'Show', @acute_rehab1_year
 '|
 = link_to 'Back', acute_rehab1_years_path
-

--- a/app/views/acute_rehab1_years/index.html.slim
+++ b/app/views/acute_rehab1_years/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing acute_rehab1_years
-
+<hr>
 table
   thead
     tr

--- a/app/views/acute_rehab1_years/new.html.slim
+++ b/app/views/acute_rehab1_years/new.html.slim
@@ -1,5 +1,5 @@
 h1 New acute_rehab1_year
-
+<hr>
 == render 'form'
 
 = link_to 'Back', acute_rehab1_years_path

--- a/app/views/acute_rehab90_days/edit.html.slim
+++ b/app/views/acute_rehab90_days/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Editing acute_rehab90_day
-
+<hr>
 == render 'form'
 
 = link_to 'Show', @acute_rehab90_day
 '|
 = link_to 'Back', acute_rehab90_days_path
-

--- a/app/views/acute_rehab90_days/index.html.slim
+++ b/app/views/acute_rehab90_days/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing acute_rehab90_days
-
+<hr>
 table
   thead
     tr

--- a/app/views/acute_rehab90_days/new.html.slim
+++ b/app/views/acute_rehab90_days/new.html.slim
@@ -1,5 +1,5 @@
 h1 New acute_rehab90_day
-
+<hr>
 == render 'form'
 
 = link_to 'Back', acute_rehab90_days_path

--- a/app/views/acute_rehabs/edit.html.slim
+++ b/app/views/acute_rehabs/edit.html.slim
@@ -1,8 +1,8 @@
 h1 Editing acute_rehab
+<hr>
 
 == render 'form'
 
 = link_to 'Show', @acute_rehab
 '|
 = link_to 'Back', acute_rehabs_path
-

--- a/app/views/acute_rehabs/index.html.slim
+++ b/app/views/acute_rehabs/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing acute_rehabs
-
+<hr>
 table
   thead
     tr

--- a/app/views/acute_rehabs/new.html.slim
+++ b/app/views/acute_rehabs/new.html.slim
@@ -1,5 +1,5 @@
 h1 New acute_rehab
-
+<hr>
 == render 'form'
 
 = link_to 'Back', acute_rehabs_path

--- a/app/views/annual_evaluations/_form.html.slim
+++ b/app/views/annual_evaluations/_form.html.slim
@@ -12,7 +12,7 @@
     = f.input :next_eval, wrapper: :horizontal_input_group
       = f.date_field :next_eval, class: "form-control"
     = f.input :is_inpatient, wrapper: :horizontal_input_group
-      = f.input_field :is_inpatient, class: "form-control"
+      = f.input_field :is_inpatient
 
     = f.input :asia_level, wrapper: :horizontal_input_group, label: :ASIA
       = f.input_field :asia_level, class: "form-control"

--- a/app/views/annual_evaluations/edit.html.slim
+++ b/app/views/annual_evaluations/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Editing annual_evaluation
-
+<hr>
 == render 'form'
 
 = link_to 'Show', @annual_evaluation
 '|
 = link_to 'Back', annual_evaluations_path
-

--- a/app/views/annual_evaluations/index.html.slim
+++ b/app/views/annual_evaluations/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing annual_evaluations
-
+<hr>
 table
   thead
     tr

--- a/app/views/annual_evaluations/new.html.slim
+++ b/app/views/annual_evaluations/new.html.slim
@@ -1,5 +1,5 @@
 h1 New Annual Evaluation
-
+<hr>
 == render 'form'
 
 = link_to 'Back', annual_evaluations_path

--- a/app/views/episode_of_cares/edit.html.slim
+++ b/app/views/episode_of_cares/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Editing episode_of_care
-
+<hr>
 == render 'form'
 
 = link_to 'Show', @episode_of_care
 '|
 = link_to 'Back', episode_of_cares_path
-

--- a/app/views/episode_of_cares/index.html.slim
+++ b/app/views/episode_of_cares/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing episode_of_cares
-
+<hr>
 table
   thead
     tr

--- a/app/views/episode_of_cares/new.html.slim
+++ b/app/views/episode_of_cares/new.html.slim
@@ -1,5 +1,5 @@
 h1 New episode_of_care
-
+<hr>
 == render 'form'
 
 = link_to 'Back', episode_of_cares_path

--- a/app/views/omr1_years/edit.html.slim
+++ b/app/views/omr1_years/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Editing omr1_year
-
+<hr>
 == render 'form'
 
 = link_to 'Show', @omr1_year
 '|
 = link_to 'Back', omr1_years_path
-

--- a/app/views/omr1_years/index.html.slim
+++ b/app/views/omr1_years/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing omr1_years
-
+<hr>
 table
   thead
     tr

--- a/app/views/omr1_years/new.html.slim
+++ b/app/views/omr1_years/new.html.slim
@@ -1,5 +1,5 @@
 h1 New omr1_year
-
+<hr>
 == render 'form'
 
 = link_to 'Back', omr1_years_path

--- a/app/views/omr90_days/edit.html.slim
+++ b/app/views/omr90_days/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Editing omr90_day
-
+<hr>
 == render 'form'
 
 = link_to 'Show', @omr90_day
 '|
 = link_to 'Back', omr90_days_path
-

--- a/app/views/omr90_days/index.html.slim
+++ b/app/views/omr90_days/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing omr90_days
-
+<hr>
 table
   thead
     tr

--- a/app/views/omr90_days/new.html.slim
+++ b/app/views/omr90_days/new.html.slim
@@ -1,5 +1,5 @@
 h1 New omr90_day
-
+<hr>
 == render 'form'
 
 = link_to 'Back', omr90_days_path

--- a/app/views/omrs/edit.html.slim
+++ b/app/views/omrs/edit.html.slim
@@ -1,8 +1,7 @@
 h1 Editing omr
-
+<hr>
 == render 'form'
 
 = link_to 'Show', @omr
 '|
 = link_to 'Back', omrs_path
-

--- a/app/views/omrs/index.html.slim
+++ b/app/views/omrs/index.html.slim
@@ -1,5 +1,5 @@
 h1 Listing omrs
-
+<hr>
 table
   thead
     tr

--- a/app/views/omrs/new.html.slim
+++ b/app/views/omrs/new.html.slim
@@ -1,5 +1,5 @@
 h1 New omr
-
+<hr>
 == render 'form'
 
 = link_to 'Back', omrs_path

--- a/app/views/patients/edit.html.slim
+++ b/app/views/patients/edit.html.slim
@@ -1,4 +1,5 @@
 h1 Editing patient
+<hr>
 div class='patient-info'
 div class='patient-nav col-md-3 well'
   p Add...

--- a/app/views/patients/index.html.slim
+++ b/app/views/patients/index.html.slim
@@ -1,5 +1,5 @@
 h1 SCI Patient Registry
-
+<hr>
 table class='table table-striped table-hover'
   thead
     tr

--- a/app/views/patients/new.html.slim
+++ b/app/views/patients/new.html.slim
@@ -1,3 +1,3 @@
 h1 New patient
-
+<hr>
 == render 'form'


### PR DESCRIPTION
I threw `<hr>`'s into the views to just have some separation of the headers from the forms. I think it helps declutter the views a bit. Also found an unnecessary form-control class on a checkbox that I removed.
