### PR TITLE
30 add types to requirements

### DIFF
--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -4,7 +4,7 @@ Term | Description
 -----|------------
 AE | Annual Evaluation - Episode of Care done each year for a SCI patient.
 AR | Acute Rehab - Episode of Care done immediately after the spinal injury.
-Station | (?) The hospital
+Station | It's a hospital
 VHA | Veterans Health Administration
 SCI | Spinal Care Injury
-OMR | (?) Outpatient Medical Record - Episode of Care for ???
+OMR | Outpatient Medical Rehabilitation

--- a/doc/requirements/acute_rehab.md
+++ b/doc/requirements/acute_rehab.md
@@ -1,43 +1,43 @@
 ## Acute Rehab
 ### START
-Data Fields | Answer Choice | Note | Attachment
+Data Fields | Answer Choice | Note | Type
 ----------------|----------------------|--------|----------------
-Date of Admission | Date field with calendar | |       
-ASIA | SCI Classification | See attachment | 
-FIM | Functional Independence | See attachment
-SWLS | Satisfaction with Life | See attachment
-KURTZKE EDSS | Multiple Sclerosis | See attachment
+Date of Admission | Date field with calendar | | Date
+ASIA | SCI Classification | Should have 2 fields "highest neurological level" and "impairment" | "High-tetra", "Low-tetra", "parapalegia", "multiple scaroliosis"
+FIM | Functional Independence | Assuming FIM total | Integer [18, 126]
+SWLS | Satisfaction with Life | Assuming a total | Integer [5, 35]
+KURTZKE EDSS | Multiple Sclerosis | Range might be wrong. | Float [1, 10]
 
 ### GOAL
-Data Fields | Answer Choice | Note | Attachment
+Data Fields | Answer Choice | Note | Type
 ----------------|----------------------|--------|----------------
-FIM | Functional Independence | See attachment
+FIM | Functional Independence | See attachment | Integer [18, 126]
 
 ### FINISH
-Data Fields | Answer Choice | Note | Attachment
+Data Fields | Answer Choice | Note | Type
 ----------------|----------------------|--------|----------------
-Date of Discharge | Date field with calendar 
-ASIA | SCI Classification  | See attachment
-FIM | Functional Independence | See attachment
-KURTZKE EDSS | Multiple Sclerosis | See attachment
-USPEQ | Veteran Experience  | See attachment
-Discharge Location | Drop Down box 
+Date of Discharge | Date field with calendar  | | Date
+ASIA | SCI Classification  | See attachment | "High-tetra", "Low-tetra"
+FIM | Functional Independence | See attachment | Integer [18, 126]
+KURTZKE EDSS | Multiple Sclerosis | See attachment | Float [1, 10]
+USPEQ | Veteran Experience  | No clue what this is | String
+Discharge Location | Drop Down box | List is incomplete | "Return to Community", "VA Nursing Home", "VA Hospital"
 
 ### FOLLOW UP - 90 Days
-Data Fields | Answer Choice | Note | Attachment
+Data Fields | Answer Choice | Note | Type
 ----------------|----------------------|--------|----------------
-90 Day Follow Up Date | Date field with calendar  
-FIM | Functional Independence | See attachment
-SWLS | Satisfaction with Life | See attachment
-CHART-SF | Participation | See attachment
-SF-8 | Health Status     | See attachment
+90 Day Follow Up Date | Date field with calendar  | | Date
+FIM | Functional Independence | See attachment | | Integer [18, 126]
+SWLS | Satisfaction with Life | See attachment | | Integer [5, 35]
+CHART-SF | Participation | See attachment | | Integer [0, 600]
+SF-8 | Health Status     | See attachment | Has 2 component scores. Mental and physical. Unclear how to roll-up. | float
 
 
 ### FOLLOW UP - One Year
-Data Fields | Answer Choice | Note | Attachment
+Data Fields | Answer Choice | Note | Type
 ----------------|----------------------|--------|----------------
-One year follow up date | Date field with calendar     
-FIM | Functional Independence | See attachment
-SWLS | Satisfaction with Life | See attachment
-CHART-SF | Participation | See attachment
-SF-8 | Health Status      | See attachment
+One year follow up date | Date field with calendar  | | Date
+FIM | Functional Independence | See attachment | | Integer [18, 126]
+SWLS | Satisfaction with Life | See attachment | | Integer [5, 35]
+CHART-SF | Participation | See attachment | | Integer [0, 600]
+SF-8 | Health Status      | See attachment | Has 2 component scores. Mental and physical. Unclear how to roll-up. | float

--- a/doc/requirements/annual_evaluation.md
+++ b/doc/requirements/annual_evaluation.md
@@ -7,35 +7,35 @@ Date of next AE due  | Date field with calendar | Same as Next AE due date on Re
 AE IN or Out patient | Check box |
 
 ### Standard Instruments
-Data Fields | Answer Choice | Note | Attachment
+Data Fields | Answer Choice | Note | Type
 ----------------|----------------------|--------|-------------------
-ASIA | SCI Classification | See attachment
-AUDIT | Alcohol Use | See attachment
-BMI | Body Mass Index | See attachment
-CAGE | Alcohol Use | See attachment
-CES-D | Depression   | See attachment
-CHART-SF | Participation | See attachment
-CYH | Health Status  | See attachment
-DAST | Drug Use | See attachment
-DUSOI | Comorbidities | See attachment
-DUSOI-A   | Comorbidities | See attachment
-FAM | Functional Assessment | See attachment
-FIM | Functional Independence | See attachment
-KURTZKE EDSS | Multiple Sclerosis | See attachment
-KURTZKE FSS | Multiple Sclerosis | See attachment
-MNFM | Function Modifiers | See attachment
-PRIME-MD | Depression |See attachment
-PUSH | Pressure Ulcers | See attachment
-SF-MPQ | Pain | See attachment
-SF-8 | Health Status | See attachment
-SWLS | Satisfaction with Life | See attachment
-PUMT-KIT | | |
+ASIA | SCI Classification | See attachment |
+AUDIT | Alcohol Use | See attachment | 
+BMI | Body Mass Index | See attachment | Float
+CAGE | Alcohol Use | See attachment | 
+CES-D | Depression   | See attachment | Integer [0, 10]
+CHART-SF | Participation | See attachment |
+CYH | Health Status  | See attachment | Integer [1, 9]
+DAST | Drug Use | See attachment |  
+DUSOI | Comorbidities | See attachment | Float
+DUSOI-A   | Comorbidities | See attachment | Float
+FAM | Functional Assessment | See attachment | Integer [1,7]
+FIM | Functional Independence | See attachment |
+KURTZKE EDSS | Multiple Sclerosis | See attachment | Float [0,10]
+KURTZKE FSS | Multiple Sclerosis | See attachment | String [0, 6] + "U" for unknown. 
+MNFM | Function Modifiers | See attachment | Integer [0,7]
+PRIME-MD | Depression |See attachment |  Integer [0,2]
+PUSH | Pressure Ulcers | See attachment | Integer [0,5]
+SF-MPQ | Pain | See attachment | |  Integer 
+SF-8 | Health Status | See attachment | |
+SWLS | Satisfaction with Life | See attachment |
+PUMT-KIT | | | |
 
 ### SCI/D Information
 
-Data Fields | Answer Choice | Note | Attachment
+Data Fields | Answer Choice | Note | Type
 ----------------|----------------------|--------|-----------------
-Bladder drainage method | Drop Down box 
-Date Colonoscopy Received | Date field with calendar | Same as Date of Last Colonoscopy on Registration tab
-Date Sigmoidoscopy Received    | Date field with calendar | Same as Date of Last Sigmoidoscopy on Registration tab
-Date of Diabetic Retinal Screening | Date field with calendar | Same as Date of Last Diabetic Retinal Screening on Registration tab
+Bladder drainage method | Drop Down box  | Incomplete list. About 10 items. | "FO - Indwelling catheter", "CC - Condom/external catheter", "VV - Voluntary Voiding"
+Date Colonoscopy Received | Date field with calendar | Same as Date of Last Colonoscopy on Registration tab | | Date
+Date Sigmoidoscopy Received    | Date field with calendar | Same as Date of Last Sigmoidoscopy on Registration tab | | Date
+Date of Diabetic Retinal Screening | Date field with calendar | Same as Date of Last Diabetic Retinal Screening on Registration tab | | Date

--- a/doc/requirements/registration.md
+++ b/doc/requirements/registration.md
@@ -3,35 +3,35 @@
 
 Data Fields | Answer Choice | Note
 ----------------|----------------------|------
-Last Name | Text box
-First Name | Text box
-Social Security Number | Text box
-Date of Birth | Text box
-Computed Age | Text box with formula
-Gender | Check box
-New Injury | Check box
-OEF/OIF/OND | Check box
-SCI Center Date of Arrival | Date field with calendar
-Active Duty | Check box: yes/no
-Assigned VAMC | Drop Down box with station #
-Assigned HUB | Drop Down box with station #
-Preferred HUB | Drop Down box with station #
-Assigned SCI Coordinator | Drop Down box with names
-PCP at Assigned HUB | Text box
-PCP at Assigned VAMC | Text box
+Last Name | Text box |
+First Name | Text box |
+Social Security Number | Text box |
+Date of Birth | Text box |
+Computed Age | Text box with formula |
+Gender | Check box | 
+New Injury | Check box |
+OEF/OIF/OND | Check box |
+SCI Center Date of Arrival | Date field with calendar |
+Active Duty | Check box: yes/no |
+Assigned VAMC | Drop Down box with station # | "100 - Richmond VAMC", "200 - Mcguire" (there are fake)
+Assigned HUB | Drop Down box with station # | "100 - Richmond VAMC", "200 - Mcguire" (there are fake)
+Preferred HUB | Drop Down box with station # | "100 - Richmond VAMC", "200 - Mcguire" (there are fake)
+Assigned SCI Coordinator | Drop Down box with names | Auto-populated with names of actual VA employees. Expect ~200 entries.
+PCP at Assigned HUB | Text box | 
+PCP at Assigned VAMC | Text box |
 
 ### SCI/D Information
 
 Data Fields | Answer Choice | Note
 ----------------|----------------------|------
 Type of SCI/D | Check box: SCI, MS, ALS, Other
-MS subtype | Drop Down box
-Date of onset | Date field with calendar
-Level of Injury| Drop Down box
-Asia Impairment Scale | Drop Down box
-Complete/Incomplete | Check box
+MS subtype | Drop Down box | "UN - Unknown", "RR - Relapsing-Remiting", "PP - Priary Progressive", "SP - Secondary Progressive", "PR - Progressive Relapsing"
+Date of onset | Date field with calendar | Date
+Level of Injury| Drop Down box | C1,C2,C3...,  T1,T2,T3,..., L1,L2,L3... (see asia levels)
+Asia Impairment Scale | Drop Down box | 
+Complete/Incomplete | Check box 
 Traumatic/Non-traumatic | Check box
-Etiology | Drop Down box
+Etiology | Drop Down box | About 50 types. Follows standards. "TFA - Fall", "TSA - Sports Activities", "TVE - Vehicular", etc
 Date of AE Offered | Date field with calendar
 Date of Last AE Received | Date field with calendar
 Next AE due date | Date field with calendar


### PR DESCRIPTION
Fixes #30.

Adds enough roughly-correct data-types for now. There's a lot of duplicated fields between report types which I didn't go copying the types over.  Anything that's not listed should be considered string for now.
