### PR TITLE
Add meta tags for bootstrap ie9 compat.

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,6 +2,9 @@ doctype html
 html
   head
     title SCI Interim
+    meta charset='utf-8'
+    meta http-equiv='X-UA-Compatible' content='IE=edge'
+    meta name='viewport' content='width=device-width, initial-scale=1'
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags


### PR DESCRIPTION
Per Bootstrap documentation, setting these meta tags (and
doctype html which is already being done) will enable IE9 to render
bootstrap UI correctly.

Briefly tested on an ie9 instance. At the very least, the viewport
seems to be better. Without these tags, the content area would
extend beyond the window frame.
