### PR TITLE
add dob validation, make dob stored, add ssn back, add gender to be s…

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,5 +1,3 @@
-#require 'pry'
-
 class PatientsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_patient, only: [:show, :edit, :update, :destroy]
@@ -46,7 +44,6 @@ class PatientsController < ApplicationController
     else
       flash[:error] = "Something went wrong updating this patient's data. Try again."
     end
-    #binding.pry
     render :edit
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,3 +1,5 @@
+#require 'pry'
+
 class PatientsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_patient, only: [:show, :edit, :update, :destroy]
@@ -44,6 +46,7 @@ class PatientsController < ApplicationController
     else
       flash[:error] = "Something went wrong updating this patient's data. Try again."
     end
+    #binding.pry
     render :edit
   end
 
@@ -58,7 +61,7 @@ class PatientsController < ApplicationController
 
     def patient_params
       params.require(:patient).permit(
-        :patient_id, :first_name, :last_name, :ssn, :dob,
+        :scido_id, :first_name, :last_name, :ssn, :dob, :gender,
         :asia_level, :asia_impairment,
         :bladder_drainage, :employment_status,
         :highest_level_of_education,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,10 +1,12 @@
 class Patient < ActiveRecord::Base
   has_many :episode_of_cares
 
-  validates_format_of :first_name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/, message: "No numbers or special chars"
-  validates_format_of :last_name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/, message: "No numbers or special chars"
-  validates :scido_id, numericality: { only_integer: true, greater_than: 0}
-  validates_format_of :ssn, :with => /\d{3}-\d{2}-\d{4}/, message: "Expect format 111-22-3333"
+  validates_format_of :first_name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/, message: "Enter the patient's first name"
+  validates_format_of :last_name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/, message: "Enter the patient's last name"
+  validates :scido_id, numericality: { only_integer: true, greater_than: 0, allow_blank: true}
+  validates_format_of :ssn, :with => /\d{3}-\d{2}-\d{4}/, message: "Format as 111-22-3333"
+  validate :dob_is_valid_date
+
 
   enum asia_level: { 'A' => 1, 'B' => 2, 'C' => 3, 'D' => 4 }
   enum gender: { "Female" => 1, "Male" => 2, "Unknown" => 3 }
@@ -68,9 +70,21 @@ class Patient < ActiveRecord::Base
     "Expired" => 4
   }
 
+  def dob_local
+    if dob
+      return localize(dob)
+    end
+    return dob
+  end
+
   def computed_age
     age = Date.today.year - dob.year
     age -= 1 if Date.today < dob + age.years
     return age
   end
+
+  def dob_is_valid_date
+    errors.add(:dob, 'must be a valid date') if (!dob.is_a?(Date))
+  end
 end
+

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -7,7 +7,6 @@ class Patient < ActiveRecord::Base
   validates_format_of :ssn, :with => /\d{3}-\d{2}-\d{4}/, message: "Format as 111-22-3333"
   validate :dob_is_valid_date
 
-
   enum asia_level: { 'A' => 1, 'B' => 2, 'C' => 3, 'D' => 4 }
   enum gender: { "Female" => 1, "Male" => 2, "Unknown" => 3 }
   enum highest_level_of_education: {
@@ -69,13 +68,6 @@ class Patient < ActiveRecord::Base
     "On-Hold" => 3,
     "Expired" => 4
   }
-
-  def dob_local
-    if dob
-      return localize(dob)
-    end
-    return dob
-  end
 
   def computed_age
     age = Date.today.year - dob.year

--- a/app/views/annual_evaluations/_form.html.slim
+++ b/app/views/annual_evaluations/_form.html.slim
@@ -3,10 +3,10 @@
   .form-inputs
     h4 Clinical
     = f.input :bmi, label: "BMI", :placeholder => "00"
-    = f.input :bladder_drainage_method,  label: "Bladder Drainage Method", :prompt => "Please select one", collection: AnnualEvaluation.bladder_drainage_methods.keys
+    = f.input :bladder_drainage_method,  label: "Bladder Drainage Method", :prompt => "Select one", collection: AnnualEvaluation.bladder_drainage_methods.keys
     = f.input :has_motor_or_sensory_asymmetry
-    = f.input :neuro_zone_of_preservation1,  label: "Neuro Zone of Preservation", :prompt => "Please select one", collection: AnnualEvaluation.neuro_zone_of_preservation1s.keys
-    = f.input :neuro_zone_of_preservation2, label: false, :prompt => "Please select one", collection: AnnualEvaluation.neuro_zone_of_preservation2s.keys
+    = f.input :neuro_zone_of_preservation1,  label: "Neuro Zone of Preservation", :prompt => "Select one", collection: AnnualEvaluation.neuro_zone_of_preservation1s.keys
+    = f.input :neuro_zone_of_preservation2, label: false, :prompt => "Select one", collection: AnnualEvaluation.neuro_zone_of_preservation2s.keys
     = f.input :neuro_zone_of_preservation3, label: false, :placeholder => "00"
 
     h4 ASIA &mdash; LOI

--- a/app/views/layouts/_patientnav.html.slim
+++ b/app/views/layouts/_patientnav.html.slim
@@ -11,8 +11,8 @@ nav.navbar.navbav-default#patient-nav
           li 
             | Age: 
             strong = @patient.computed_age
-            |  DoB: 
-            strong = @patient.dob 
+            |  DOB: 
+            strong = localize(@patient.dob)
           li
             | SSN: 
             strong = @patient.ssn

--- a/app/views/patients/_form.html.slim
+++ b/app/views/patients/_form.html.slim
@@ -10,10 +10,12 @@
         .panel-body
           = f.input :first_name
           = f.input :last_name
-          = f.input :dob, as: :string, input_html: { class: "datepicker" }
-          = f.input :gender, collection: Patient.genders.keys
-          = f.input :scido_id, label: "SCIDO Patient Id", readonly: true
-
+          = f.input :dob, as: :date, html5: true, label: "Date of Birth"
+          = f.input :gender, collection: Patient.genders.keys, :prompt => "Select one"
+          = f.input :ssn, label: "SSN", :placeholder => "111-22-3333"
+          = f.input :scido_id, label: "SCIDO Patient Id"
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     .panel.panel-default
       #headingContactInfo.panel-heading role="tab" data-parent="#accordion" data-toggle="collapse" href="#contactInfo"
         h4.panel-title
@@ -24,7 +26,8 @@
           p Patient contact info here.
           = f.input :my_healthevet_messaging
           = f.input :sci_service_connected
-
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     .panel.panel-default
       #headingTravelEligibility.panel-heading role="tab" data-parent="#accordion" data-toggle="collapse" href="#travelEligibility"
         h4.panel-title
@@ -34,7 +37,8 @@
         .panel-body
           = f.input :travel_status, collection: Patient.travel_statuses.keys
           = f.input :benefits_waiver_exemption_date, as: :string, input_html: { class: "datepicker" }
-
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     .panel.panel-default
       #headingVAStatus.panel-heading role="tab" data-parent="#accordion" data-toggle="collapse" href="#vaStatus"
         h4.panel-title
@@ -50,7 +54,8 @@
           = f.input :preferred_sci_hub
           = f.input :preferred_sci_hub_physician_first_name
           = f.input :preferred_sci_hub_physician_last_name
-
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     .panel.panel-default
       #headingPrimaryCare.panel-heading role="tab" data-parent="#accordion" data-toggle="collapse" href="#primaryCare"
         h4.panel-title
@@ -67,7 +72,8 @@
           = f.input :va_facility
           = f.input :va_facility_pcp_first_name
           = f.input :va_facility_pcp_last_name
-
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     .panel.panel-default
       #headingSCIDInfo.panel-heading role="tab" data-parent="#accordion" data-toggle="collapse" href="#scidInfo"
         h4.panel-title
@@ -83,7 +89,8 @@
           = f.input :level_of_injury, collection: Patient.level_of_injuries.keys
           = f.input :asia_level, collection: Patient.asia_levels.keys
           = f.input :is_asia_complete
-
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     .panel.panel-default
       #headingPsychosocial.panel-heading role="tab" data-parent="#accordion" data-toggle="collapse" href="#psychosocial"
         h4.panel-title
@@ -94,7 +101,8 @@
           = f.input :highest_level_of_education, collection: Patient.highest_level_of_educations.keys
           = f.input :occupation_at_time_of_injury
           = f.input :current_occupation
-
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     .panel.panel-default
       #headingResidencyAndCaregiver.panel-heading role="tab" data-parent="#accordion" data-toggle="collapse" href="#residencyAndCaregiver"
         h4.panel-title
@@ -111,7 +119,8 @@
           = f.input :non_va_caregiver_receiving_reimbursement
           = f.input :last_fee_basis_evaluation_date, as: :string, input_html: { class: "datepicker" }
           = f.input :is_receiving_hhha
-
+          .col-sm-offset-3.col-sm-9.form-actions
+            = f.submit class:"btn btn-primary"
     - if @patient
       .panel.panel-default
         #detailThree.panel-heading role="tab" data-toggle="collapse" href="#episodesOfCare"
@@ -128,3 +137,4 @@
                     = episode.episode_date
                   td
                     = episode.specific.class.name
+

--- a/app/views/patients/index.html.slim
+++ b/app/views/patients/index.html.slim
@@ -24,4 +24,4 @@ table class='table table-striped table-hover'
           td: a href="#{edit_patient_path(patient)}"  = patient.first_name
           td: a href="#{edit_patient_path(patient)}"  = patient.last_name
           td = patient.ssn
-          td = patient.dob
+          td = localize(patient.dob) if patient.dob

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -24,3 +24,11 @@ en:
     #     username: 'User name to sign in.'
     #     password: 'No special characters, please.'
 
+  date:
+    formats:
+      # Use the strftime parameters for formats.
+      # When no format has been given, it uses default.
+      # You can provide other formats here if you like!
+      default: "%m/%d/%Y"
+      short: "%b %d"
+      long: "%B %d, %Y"


### PR DESCRIPTION
added
- For DOB
  - validation: MM/DD/YYYY #134 
  - added localized view for date so you see date as MM/DD/YYYY even when it's stored as YYYY-DD-MM
  - make required field
  - make it forced format in HTML5, this might get kicked back in user testing depending on what browser they are using
- rewrote some error messages to be more applicable
- add ssn back to registration page
- add gender to be stored in patient
- annnnnd add submit buttons / update buttons to registration page, in each accordion section

@awong-dev Are scido_id and patient_id doing the same purpose? I seem to remember we replaced the former with the latter, but we didn't update it across the board, but wanted to verify before removing patient_id. <-- addressed in #138 and #137 
