### PR TITLE
Implement address forms for patients.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'bootstrap-sass', '~> 3.2.0.2'
 gem 'bootstrap-datepicker-rails'
 gem 'coffee-rails', '~> 4.0.0'
+gem 'country_select'
 gem 'devise'
 gem 'faker'  # TODO(awong): Move to :development,:test after db/seeds.rb gets real data.
 gem 'foreigner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,12 +68,19 @@ GEM
       execjs
     coffee-script-source (1.9.1.1)
     columnize (0.9.0)
+    countries (0.11.5)
+      currencies (~> 0.4.2)
+      i18n_data (~> 0.7.0)
+    country_select (2.2.0)
+      countries (~> 0.11.0)
+      sort_alphabetical (~> 1.0)
     coveralls (0.8.1)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
       simplecov (~> 0.10.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+    currencies (0.4.2)
     debug_inspector (0.0.2)
     devise (3.5.1)
       bcrypt (~> 3.0)
@@ -122,6 +129,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    i18n_data (0.7.0)
     immigrant (0.3.4)
       activerecord (>= 3.0)
     jbuilder (2.2.16)
@@ -261,6 +269,8 @@ GEM
       railties (>= 3.1, < 5.0)
       slim (~> 3.0)
     slop (3.6.0)
+    sort_alphabetical (1.0.1)
+      unicode_utils (>= 1.2.2)
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -293,6 +303,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    unicode_utils (1.4.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     warden (1.2.3)
@@ -314,6 +325,7 @@ DEPENDENCIES
   byebug
   capybara-webkit
   coffee-rails (~> 4.0.0)
+  country_select
   coveralls
   devise
   factory_girl_rails
@@ -340,6 +352,3 @@ DEPENDENCIES
   timecop
   turbolinks
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.10.4

--- a/app/controllers/concerns/attribute_param.rb
+++ b/app/controllers/concerns/attribute_param.rb
@@ -1,0 +1,11 @@
+module AttributeParam
+  extend ActiveSupport::Concern
+
+  # Takes a model and geneates a list of attribute names suitable for use with
+  # StrongParams.
+  #
+  # In particular, removes the timestamp columns.
+  def nested_model_attributes(model)
+    model.attribute_names.reject { |name| ['created_at', 'updated_at'].include?(name) }
+  end
+end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,4 +1,6 @@
 class PatientsController < ApplicationController
+  include AttributeParam 
+
   before_action :authenticate_user!
   before_action :set_patient, only: [:show, :edit, :update, :destroy]
 
@@ -20,6 +22,8 @@ class PatientsController < ApplicationController
 
   def new
     @patient = Patient.new
+    @patient.build_address
+    @patient.build_caregiver_address
     respond_with(@patient)
   end
 
@@ -29,6 +33,7 @@ class PatientsController < ApplicationController
 
   def create
     @patient = Patient.new(patient_params)
+    @patient.assign_attributes(patient_params)
     if @patient.save
       flash[:success] = "You have successfully created a patient."
       render :edit
@@ -39,6 +44,7 @@ class PatientsController < ApplicationController
   end
 
   def update
+    @patient.assign_attributes(patient_params)
     if @patient.update(patient_params)
       flash[:success] = "You have successfully updated this patient's data"
     else
@@ -72,6 +78,9 @@ class PatientsController < ApplicationController
         :annual_eval_received, :annual_eval_next_due,
         :initial_rehab_site, :initial_rehab_discharge,
         :data_first_seen_in_va_sci, :occupation_at_time_of_injury,
-        :service_connected, :date_of_death, :outcome_coordinator)
+        :service_connected, :date_of_death, :outcome_coordinator,
+        address_attributes: nested_model_attributes(Address),
+        caregiver_address_attributes: nested_model_attributes(Address),
+        )
     end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ActiveRecord::Base
+  has_one :patient
+end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,6 +1,12 @@
 class Patient < ActiveRecord::Base
   has_many :episode_of_cares
 
+  belongs_to :address, class_name: 'Address'
+  accepts_nested_attributes_for :address
+
+  belongs_to :caregiver_address, class_name: 'Address', foreign_key: 'caregiver_address_id'
+  accepts_nested_attributes_for :caregiver_address
+
   validates_format_of :first_name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/, message: "Enter the patient's first name"
   validates_format_of :last_name, :with => /\A[^0-9`!@#\$%\^&*+_=]+\z/, message: "Enter the patient's last name"
   validates :scido_id, numericality: { only_integer: true, greater_than: 0, allow_blank: true}

--- a/app/views/patients/_form.html.slim
+++ b/app/views/patients/_form.html.slim
@@ -23,7 +23,8 @@
             | Contact Information
       #contactInfo.panel-collapse.collapse aria-labelledby="headingBasic" role="tabpanel"
         .panel-body
-          p Patient contact info here.
+          = f.simple_fields_for :address do |address|
+            = render 'shared/address_fields', :f => address 
           = f.input :my_healthevet_messaging
           = f.input :sci_service_connected
           .col-sm-offset-3.col-sm-9.form-actions
@@ -113,7 +114,8 @@
           = f.input :residence_type
           = f.input :residence_name
           = f.input :has_caregiver
-          p Add Address here.
+          = f.simple_fields_for :caregiver_address do |caregiver_address|
+            = render 'shared/address_fields', :f => caregiver_address 
           = f.input :is_receiving_non_va_care
           = f.input :non_va_care_hours_per_month
           = f.input :non_va_caregiver_receiving_reimbursement

--- a/app/views/shared/_address_fields.html.slim
+++ b/app/views/shared/_address_fields.html.slim
@@ -1,0 +1,9 @@
+.nested-fields
+  = f.input :name
+  = f.input :address1
+  = f.input :address2
+  = f.input :city
+  = f.input :state
+  = f.input :zip
+  = f.input :zip_plus4
+  = f.input :country

--- a/db/migrate/20150716005315_fix_patient_address.rb
+++ b/db/migrate/20150716005315_fix_patient_address.rb
@@ -1,0 +1,26 @@
+class FixPatientAddress < ActiveRecord::Migration
+  def change
+
+    # rename address to address_id to not confuse rails.
+    remove_foreign_key :patients, column: :address, dependent: :delete
+    remove_column :patients, :address, :integer
+    add_column :patients, :address_id, :integer, null: false
+    add_foreign_key :patients, :addresses, column: :address_id, dependent: :delete
+    Patient.all.each do |patient|
+      patient.create_address
+      patient.save!
+    end
+    add_index :patients, :address_id, unique: true
+
+    # rename caregiver_address to caregiver_address_id to not confuse rails.
+    remove_foreign_key :patients, column: :caregiver_address, dependent: :delete
+    remove_column :patients, :caregiver_address, :integer
+    add_column :patients, :caregiver_address_id, :integer, null: false
+    add_foreign_key :patients, :addresses, column: :caregiver_address_id, dependent: :delete
+    Patient.all.each do |patient|
+      patient.create_caregiver_address
+      patient.save!
+    end
+    add_index :patients, :caregiver_address_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150716005314) do
+ActiveRecord::Schema.define(version: 20150716005315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,7 +128,6 @@ ActiveRecord::Schema.define(version: 20150716005314) do
     t.string   "occupation_at_time_of_injury"
     t.string   "last_name"
     t.integer  "gender"
-    t.integer  "address"
     t.boolean  "my_healthevet_messaging"
     t.boolean  "sci_service_connected"
     t.integer  "travel_status"
@@ -161,13 +160,17 @@ ActiveRecord::Schema.define(version: 20150716005314) do
     t.integer  "residence_type"
     t.string   "residence_name"
     t.boolean  "has_caregiver"
-    t.integer  "caregiver_address"
     t.boolean  "is_receiving_non_va_care"
     t.integer  "non_va_care_hours_per_month"
     t.string   "non_va_caregiver_receiving_reimbursement"
     t.date     "last_fee_basis_evaluation_date"
     t.boolean  "is_receiving_hhha"
+    t.integer  "address_id",                               null: false
+    t.integer  "caregiver_address_id",                     null: false
   end
+
+  add_index "patients", ["address_id"], name: "index_patients_on_address_id", unique: true, using: :btree
+  add_index "patients", ["caregiver_address_id"], name: "index_patients_on_caregiver_address_id", unique: true, using: :btree
 
   create_table "transfers", force: true do |t|
     t.integer  "acute_rehabs_id"
@@ -199,7 +202,7 @@ ActiveRecord::Schema.define(version: 20150716005314) do
 
   add_foreign_key "episode_of_cares", "patients", name: "episode_of_cares_patient_id_fk"
 
-  add_foreign_key "patients", "addresses", name: "patients_address_fk", column: "address", dependent: :delete
-  add_foreign_key "patients", "addresses", name: "patients_caregiver_address_fk", column: "caregiver_address", dependent: :delete
+  add_foreign_key "patients", "addresses", name: "patients_address_id_fk", dependent: :delete
+  add_foreign_key "patients", "addresses", name: "patients_caregiver_address_id_fk", column: "caregiver_address_id", dependent: :delete
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,7 +67,10 @@ for i in 1..50
     last_fee_basis_evaluation_date: Faker::Date.between(100.years.ago, Date.today),
     is_receiving_hhha: [true, false].sample,
   }
-  patient = Patient.create!(patient_data)
+  patient = Patient.new(patient_data)
+  patient.create_address
+  patient.create_caregiver_address
+  patient.save!
 
 
   # AR

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  Faker::Config.locale = 'en-US'
+
+  factory :address do
+    created_at Time.now
+    updated_at Time.now
+
+    name { Faker::Name.name }
+    address1 { Faker::Address.street_address }
+    address2 { Faker::Address.secondary_address }
+    city { Faker::Address.city }
+    state { Faker::Address.state }
+    zip { Faker::Address.zip }
+    zip_plus4 { Faker::Number.number(4) }
+    country { Faker::Address.country }
+  end
+end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -13,7 +13,7 @@ FactoryGirl.define do
     highest_level_of_education { Patient.highest_level_of_educations.keys.sample }
     occupation_at_time_of_injury { Faker::Lorem.sentence(3) }
     gender { Patient.genders.keys.sample }
-    # TODO(awong): Add address 
+    address { create(:address) }
     my_healthevet_messaging { [true, false].sample }
     sci_service_connected { [true, false].sample }
     travel_status { Patient.travel_statuses.keys.sample }
@@ -48,7 +48,7 @@ FactoryGirl.define do
     residence_type { AcuteRehab.residence_types.keys.sample }
     residence_name { Faker::Company.name }
     has_caregiver { [true, false].sample }
-    # TODO(awong): Create a caregiver_address 
+    caregiver_address { create(:address) }
     is_receiving_non_va_care { [true, false].sample }
     non_va_care_hours_per_month { rand(1000) }
     non_va_caregiver_receiving_reimbursement { Faker::Company.name }


### PR DESCRIPTION
- Corrects the foreign key relations between the address table an
  patients.
- Decided to store the FK in the patients table to reduce null
  rows in address table.
- Added constraints to force address to exist. If address doesn't
  exist, simple_form helpfully doesn't render anything rather than
  erroring.
- Added country_select gem because simple_form automagically notices
  a field named :country and attempts to create a dropdown which
  blows up without the gem
- Fixed the seeding.
- caregiver_address doesn't correctly save. If you look at request
  parameters, simple_form is NOT generating a correctly name
  caregiver_address_attributes hash. Not sure why.
