### PR TITLE
Fix heroku deploy to auto-migrate.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-ruby.git
+https://github.com/gunpowderlabs/buildpack-ruby-db-migrate.git

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name":"SCIInterim",
   "scripts":{
-    "postdeploy":"rake db:migrate db:seed app:seed_fake"
+    "postdeploy":"bundle exec rake db:migrate db:seed app:seed_fake"
    },
   "env":{
     "LANG":{


### PR DESCRIPTION
- Use heroku-buildpack-multi to execute 2 buildpacks: One for
  installing the bundler gems. The other for running db:migrate.
- Invoke rails under bundle exec for doing datbase seeding on first
  deploy.
