### PR TITLE
Remove extraneous label_method and value_method.

### DIFF
--- a/app/views/acute_rehabs/_form.html.slim
+++ b/app/views/acute_rehabs/_form.html.slim
@@ -8,8 +8,6 @@
             .col-md-8
                 = f.input :reason_for_admission,
                 collection: AcuteRehab.collections[:reason_for_admission],
-                label_method: :name,
-                value_method: :id,
                 as: :radio_buttons,
                 item_wrapper_class: 'radio-inline'
             .col-md-4
@@ -31,8 +29,6 @@
             .col-md-4
                 = f.input :discharge_location,
                 collection: AcuteRehab.collections[:discharge_location],
-                label_method: :name,
-                value_method: :id,
                 :prompt => "Select one"
 
     .callout-blank

--- a/app/views/annual_evaluations/_form.html.slim
+++ b/app/views/annual_evaluations/_form.html.slim
@@ -10,8 +10,6 @@
           = f.input :bladder_drainage_method,
           label: "Bladder Drainage Method",
           collection: AnnualEvaluation.collections[:bladder_drainage_method],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one"
     = f.simple_fields_for :asia_assessment do |asia_assessment|
         = render 'shared/asia_fields', :f => asia_assessment

--- a/app/views/patients/_form.html.slim
+++ b/app/views/patients/_form.html.slim
@@ -16,8 +16,6 @@
           label.control-label.radio.radio-inline Gender
           = f.input_field :gender,
           collection: Patient.collections[:gender],
-          label_method: :name,
-          value_method: :id,
           as: :radio_buttons,
           item_wrapper_class: 'radio-inline'
       hr
@@ -43,8 +41,6 @@
         .col-md-6
           = f.input :assigned_vamc, :label => "Assigned VAMC",
           collection: Patient.collections[:assigned_vamc],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one"
         .col-md-6
           / TOODO: Should be conditional on last radio selected
@@ -54,8 +50,6 @@
           label.control-label.radio.radio-inline Travel status
           = f.input_field :travel_status,
             collection: Patient.collections[:travel_status],
-            label_method: :name,
-            value_method: :id,
             as: :radio_buttons,
             item_wrapper_class: 'radio-inline'
     .callout
@@ -83,8 +77,6 @@
       = f.input_field :principle_pcp_va_nonva,
         label: "Primary Care Physician",
         collection: Patient.collections[:principle_pcp_va_nonva],
-        label_method: :name,
-        value_method: :id,
         as: :radio_buttons,
         item_wrapper_class: 'radio-inline'
     .callout
@@ -114,14 +106,10 @@
         .col-md-6
           = f.input :sci_type,
           collection: Patient.collections[:sci_type],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one",
           label: "SCI Type"
           = f.input :scid_eligibility,
           collection: Patient.collections[:scid_eligibility],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one",
           label: "SCI/D Eligibility"
           / only if other is selected above
@@ -133,8 +121,6 @@
           label.control-label.radio.radio-inline Theater of service
           = f.input_field :theater_of_service,
           collection: Patient.collections[:theater_of_service],
-          label_method: :name,
-          value_method: :id,
           as: :radio_buttons,
           item_wrapper_class: 'radio-inline'
       / TODO conditional only if SCI is selected above
@@ -142,8 +128,6 @@
         .col-md-6
           = f.input :scid_etiology,
           collection: Patient.collections[:scid_etiology],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one",
           label: "SCI/D Etiology"
         .col-md-6
@@ -158,27 +142,19 @@
         .col-md-6
           = f.input :highest_level_of_education,
           collection: Patient.collections[:highest_level_of_education],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one"
         .col-md-6
           = f.input :occupation_at_time_of_injury,
           collection: Patient.collections[:occupation_at_time_of_injury],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one"
       .row
         .col-md-6
           = f.input :current_occupation,
           collection: Patient.collections[:current_occupation],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one"
         .col-md-6
           = f.input :residence_type,
           collection: Patient.collections[:residence_type],
-          label_method: :name,
-          value_method: :id,
           prompt: "Select one"
     .callout
       h4 Caregiver Information
@@ -187,8 +163,6 @@
           label.control-label.radio.radio-inline Caregiver type
           = f.input_field :has_caregiver, label: "Caregiver type",
           collection: Patient.collections[:has_caregiver],
-          label_method: :name,
-          value_method: :id,
           as: :radio_buttons,
           item_wrapper_class: 'radio-inline'
         .col-md-4

--- a/app/views/shared/_asia_fields.html.slim
+++ b/app/views/shared/_asia_fields.html.slim
@@ -19,29 +19,21 @@
                 td 
                   = f.input_field :neurological_sensory_level_left,
                   label: false,
-                  collection: Asia.collections[:neurological_sensory_level_left],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:neurological_sensory_level_left]
                 td 
                   = f.input_field :neurological_sensory_level_right,
                   label: false,
-                  collection: Asia.collections[:neurological_sensory_level_right],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:neurological_sensory_level_right]
               tr
                 th scope="row"  Motor
                 td 
                   = f.input_field :neurological_motor_level_left,
                   label: false,
-                  collection: Asia.collections[:neurological_motor_level_left],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:neurological_motor_level_left]
                 td 
                   = f.input_field :neurological_motor_level_right,
                   label: false,
-                  collection: Asia.collections[:neurological_motor_level_right],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:neurological_motor_level_right]
       .col-md-4
         label ASIA Impairment Scale
         .form-control.input Missing JS auto-calc
@@ -75,25 +67,17 @@
                 th scope="row"  Sensory
                 td 
                   = f.input_field :preservation_sensory_left,
-                  collection: Asia.collections[:preservation_sensory_left],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:preservation_sensory_left]
                 td 
                   = f.input_field :preservation_sensory_right,
-                  collection: Asia.collections[:preservation_sensory_right],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:preservation_sensory_right]
               tr
                 th scope="row"  Motor
                 td 
                   = f.input_field :preservation_motor_left,
                   label: false,
-                  collection: Asia.collections[:preservation_motor_left],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:preservation_motor_left]
                 td 
                   = f.input_field :preservation_motor_right,
                   label: false,
-                  collection: Asia.collections[:preservation_motor_right],
-                  label_method: :name,
-                  value_method: :id
+                  collection: Asia.collections[:preservation_motor_right]


### PR DESCRIPTION
simple_form, it turns out, is smart enough to inspect the object in the
collection to guess at the label_method and value_method. If it's an
array it guesses first and second map to label and value. If it's an
object, it looks for "common" label and value methods. These are
settable in the simple_forms initilizer (see config.collection_label_methods
aond config.collection_value_methods) but the default includes :name and
:id for the label and value methods. This works great with the
convention being used with our domain tables of having the value be the
id and the name be the option string.

Thus, this CL deletes a bunch of extra crufty lines.
