### PR TITLE
Normalize datepicker to new custom :date_picker.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,3 +373,6 @@ DEPENDENCIES
   timecop
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/inputs/date_picker_input.rb
+++ b/app/inputs/date_picker_input.rb
@@ -1,0 +1,11 @@
+class DatePickerInput < SimpleForm::Inputs::StringInput
+  def input_html_options
+    value = object.send(attribute_name)
+    options = {
+      value: value.nil? ? nil : I18n.localize(value),
+      type: "date",
+    }
+    # add all html option you need...
+    super.merge options
+  end
+end

--- a/app/views/acute_rehabs/_form.html.slim
+++ b/app/views/acute_rehabs/_form.html.slim
@@ -14,17 +14,17 @@
                 = f.input :reason_for_admission_other
         .row
             .col-md-4
-                = f.input :hospital_admission, as: :string, input_html: { class: "datepicker" }, :label => "Hospital admission date",  :placeholder => "DD/MM/YYYY"
+                = f.input :hospital_admission, as: :date_picker, :label => "Hospital admission date"
             .col-md-4
-                = f.input :acute_rehab_admission, as: :string, input_html: { class: "datepicker" }, :label => "Acute rehab admission date", :placeholder => "DD/MM/YYYY"
+                = f.input :acute_rehab_admission, as: :date_picker, :label => "Acute rehab admission date"
 
     .callout
         h4 Discharge
         .row
             .col-md-4
-                = f.input :hospital_discharge, as: :string, input_html: { class: "datepicker" }, :label => "Hospital discharge date",  :placeholder => "DD/MM/YYYY"
+                = f.input :hospital_discharge, as: :date_picker, :label => "Hospital discharge date"
             .col-md-4
-                = f.input :acute_rehab_discharge, as: :string, input_html: { class: "datepicker" }, :label => "Acute rehab discharge date", :placeholder => "DD/MM/YYYY"        
+                = f.input :acute_rehab_discharge, as: :date_picker, :label => "Acute rehab discharge date"
         .row
             .col-md-4
                 = f.input :discharge_location,
@@ -51,7 +51,7 @@
 
     .callout-blank
         h4 Followup 90 Days
-        = f.input :followup_90day_date, as: :string, input_html: { class: "datepicker" }
+        = f.input :followup_90day_date, as: :date_picker
         = f.input :followup_90day_fim
         = f.input :followup_90day_swls
         = f.input :followup_90day_chart_sf
@@ -59,7 +59,7 @@
 
     .callout-blank
         h4 Followup 1 Year
-        = f.input :followup_1yr_date, as: :string, input_html: { class: "datepicker" }
+        = f.input :followup_1yr_date, as: :date_picker
         = f.input :followup_1yr_fim
         = f.input :followup_1yr_swls
         = f.input :followup_1yr_chart_sf

--- a/app/views/annual_evaluations/_form.html.slim
+++ b/app/views/annual_evaluations/_form.html.slim
@@ -23,11 +23,11 @@
             :as => :radio_buttons, 
             :item_wrapper_class => 'radio-inline'
         .col-md-4
-          = f.input :eval_offered, label: "Date Offered", :placeholder => "DD/MM/YYYY", as: :string, input_html: { class: "datepicker" }
+          = f.input :eval_offered, label: "Date Offered", as: :date_picker
         .col-md-4
-          = f.input :eval_completed, label: "Date of Completion", :placeholder => "DD/MM/YYYY", as: :string, input_html: { class: "datepicker" }
+          = f.input :eval_completed, label: "Date of Completion", as: :date_picker
         .col-md-4
-          = f.input :eval_completed, label: "Next Annual Evaluation due:", :placeholder => "DD/MM/YYYY",  disabled: true, as: :string, input_html: { class: "datepicker" }
+          = f.input :eval_completed, label: "Next Annual Evaluation due:", disabled: true, as: :date_picker
     .callout-blank
       h4 Standard Instruments
       / TODO for instruments (@emilyville)

--- a/app/views/patients/_form.html.slim
+++ b/app/views/patients/_form.html.slim
@@ -9,7 +9,7 @@
         .col-md-4
           = f.input :last_name
         .col-md-4
-          = f.input :dob, as: :date, html5: true, label: "Date of Birth"
+          = f.input :dob, as: :date_picker, label: "Date of Birth"
         .col-md-4
           = f.input :ssn, label: "SSN", :placeholder => "111-22-3333"
         .col-md-8
@@ -44,7 +44,7 @@
           prompt: "Select one"
         .col-md-6
           / TOODO: Should be conditional on last radio selected
-          = f.input :benefits_waiver_exemption_date, as: :string, input_html: { class: "datepicker" }, placeholder: "will be conditional upon travel status"
+          = f.input :benefits_waiver_exemption_date, as: :date_picker, placeholder: "will be conditional upon travel status"
       .row
         .col-md-12
           label.control-label.radio.radio-inline Travel status
@@ -116,7 +116,7 @@
           = f.input :scid_eligibility_other, label: "Other"
           = f.input :is_on_active_duty, label: "Currently on Active Duty"
         .col-md-6
-          = f.input :sci_arrival_date, as: :string, input_html: { class: "datepicker" }, label: "SCI Arrival Date"
+          = f.input :sci_arrival_date, as: :date_picker, label: "SCI Arrival Date"
         .col-md-12
           label.control-label.radio.radio-inline Theater of service
           = f.input_field :theater_of_service,
@@ -131,7 +131,7 @@
           prompt: "Select one",
           label: "SCI/D Etiology"
         .col-md-6
-          = f.input :date_of_injury, as: :date, html5: true
+          = f.input :date_of_injury, as: :date_picker
       .row
         = f.simple_fields_for :asia_assessment do |asia_assessment|
           = render 'shared/asia_fields', :f => asia_assessment
@@ -183,7 +183,7 @@
         .col-md-6
           = f.input :non_va_care_hours_per_month, label: "Care hours per month"
         .col-md-6
-          = f.input :last_fee_basis_evaluation_date, as: :string, input_html: { class: "datepicker" }, label: "Date of last bowel/bladder non VA care evaluation"
+          = f.input :last_fee_basis_evaluation_date, as: :date_picker, label: "Date of last bowel/bladder non VA care evaluation"
       .row
        .col-sm-offset-8.col-sm-4.form-actions
         = f.submit class:"btn btn-primary btn-lg btn-block"


### PR DESCRIPTION
For now just normalize everything to a custom simple_forms input type that
uses the html5 date on the input fields. Next up will be writing fallback
from html5 -> a javascript datepicker (likely jQuery-ui) for browser
compat.

fixes #151
fixes #171
fixes #173
fixes #174
fixes #175
fixes #191
fixes #192
fixes #193
fixes #194
