### PR TITLE
move asia UI around to match access and add conditionals

### DIFF
--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -38,3 +38,9 @@ function showWhenValueEqualsOptions(selector, toggleValue, toggleSelector, actio
   });
   $(selector).trigger(action);
 }
+
+$(document).ready(function() {
+  // ASIA Conditional things
+  showWhenValueEquals("[name='patient[asia_assessment][has_motor_or_sensory_asymmetry]']", "true", "#asymmetry");
+  showWhenValueEquals("[name='patient[asia_assessment][is_complete]']", "true", "#complete");
+});

--- a/app/assets/stylesheets/global.css.scss
+++ b/app/assets/stylesheets/global.css.scss
@@ -170,7 +170,7 @@ h4 {
   }
 }
 
-.hide .instrument {
+.hide {
   border: none;
   padding: 0px;
   margin: 0px;

--- a/app/views/patients/_form_isncsci.html.slim
+++ b/app/views/patients/_form_isncsci.html.slim
@@ -6,8 +6,8 @@
       h4 SCI/D Information
       .row
         .medium-12.columns
-          /TODO: @awong make asia changed yes/no
-          /TODO: @emilyville make show hide once exists
+          /TODO: @awong make asia changed yes/no/new (need to verify options)
+          /TODO: @emilyville make show hide for asia partial once exists
           label.control-label.radio Has there been any change in SCI Classification/ASIA?
           = f.input :is_on_active_duty, 
           as: :radio_buttons,

--- a/app/views/shared/_asia_fields.html.slim
+++ b/app/views/shared/_asia_fields.html.slim
@@ -1,80 +1,70 @@
 .nested-fields
-  .instrument
-    h4 ASIA Assessment Score
+  h4 ASIA Assessment Score
+  .row
+    .medium-4.columns
+      label Neurological Level of Injury
+      / TODO: @awong add field for overall NLOI
+      = f.input :neurological_sensory_level_right_id,
+      label: false,
+      collection: Domain::LevelOfInjury.cached_all
+    .medium-4.columns.left
+      / TODO: @awong I think this is backwards. False should be asymmetrical
+      label Sensory and Motor Levels Symmetrical?
+      = f.input :has_motor_or_sensory_asymmetry,
+      as: :radio_buttons,
+      item_wrapper_class: 'radio-inline',
+      label: false
+  .instrument#asymmetry.hide
+    h4 If Asymmetrical, Fill in Information for Neurological Level of Injury
     .row
-      .medium-6.columns
-        label Neurological Level
-        .table-responsive
-          table.table.table-bordered.table-striped
-            thead
-              tr
-                th 
-                th Left
-                th Right
-            tbody
-              tr
-                th scope="row"  Sensory
-                td 
-                  = f.input_field :neurological_sensory_level_left_id,
-                  label: false,
-                  collection: Domain::LevelOfInjury.cached_all
-                td 
-                  = f.input_field :neurological_sensory_level_right_id,
-                  label: false,
-                  collection: Domain::LevelOfInjury.cached_all
-              tr
-                th scope="row"  Motor
-                td 
-                  = f.input_field :neurological_motor_level_left_id,
-                  label: false,
-                  collection: Domain::LevelOfInjury.cached_all
-                td 
-                  = f.input_field :neurological_motor_level_right_id,
-                  label: false,
-                  collection: Domain::LevelOfInjury.cached_all
-      .medium-6.columns
-        label Zone of Partial Preservation
-        .table-responsive
-          table.table.table-bordered.table-striped
-            thead
-              tr
-                th 
-                th Left
-                th Right
-            tbody
-              tr
-                th scope="row"  Sensory
-                td 
-                  = f.input_field :preservation_sensory_level_left_id,
-                  collection: Domain::LevelOfInjury.cached_all
-                td 
-                  = f.input_field :preservation_sensory_level_right_id,
-                  collection: Domain::LevelOfInjury.cached_all
-              tr
-                th scope="row"  Motor
-                td 
-                  = f.input_field :preservation_motor_level_left_id,
-                  label: false,
-                  collection: Domain::LevelOfInjury.cached_all
-                td 
-                  = f.input_field :preservation_motor_level_right_id,
-                  label: false,
-                  collection: Domain::LevelOfInjury.cached_all
-      .medium-6.columns
-        label ASIA Impairment Scale
-        .form-control.input Missing JS auto-calc
-        / TODO: when these are functional we won't need breaks
-        br
-        label
-          .checkbox-inline
-            = f.input :has_motor_or_sensory_asymmetry
-      .medium-6.columns
-        label Neurological Level of Injury
-        .form-control.input Missing JS auto-calc
-        br
-        / TODO: when these are functional we won't need breaks
-        = f.input :is_complete, 
-        collection: [["Complete", true], ["Incomplete", false] ],
-        label: false,
-        as: :radio_buttons, 
-        item_wrapper_class: 'radio-inline'
+      .medium-4.columns
+        = f.input :neurological_sensory_level_right_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Sensory Right"
+        = f.input :neurological_sensory_level_left_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Sensory Left"
+      .medium-4.columns.left
+        = f.input :neurological_motor_level_right_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Motor Right"
+        = f.input :neurological_motor_level_left_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Motor Left"
+  .row
+    .medium-4.columns
+      label ASIA Impairment Scale
+      / TODO: @awong add field for ASIA impairment Scale
+      = f.input :neurological_sensory_level_right_id,
+      label: false,
+      collection: Domain::LevelOfInjury.cached_all
+    .medium-4.columns.left
+      label Injury Complete or Incomplete
+      = f.input :is_complete, 
+      collection: [["Complete", true], ["Incomplete", false] ],
+      label: false,
+      as: :radio_buttons, 
+      item_wrapper_class: 'radio-inline'
+  .instrument#complete.hide
+    h4 If Complete, Fill in Information for Zone of Partial Preservation
+    .row
+      .medium-4.columns
+        = f.input :preservation_sensory_level_right_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Sensory Right"
+        = f.input :preservation_sensory_level_left_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Sensory Left"
+      .medium-4.columns.left
+        = f.input :preservation_motor_level_right_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Motor Right"
+        = f.input :preservation_motor_level_left_id,
+        collection: Domain::LevelOfInjury.cached_all,
+        label: "Motor Left"
+
+javascript:
+  $(document).ready(function() {
+    showWhenValueEquals("[name='patient[asia_assessment][has_motor_or_sensory_asymmetry]']", "true", "#asymmetry");
+    showWhenValueEquals("[name='patient[asia_assessment][is_complete]']", "true", "#complete");
+  });

--- a/app/views/shared/_asia_fields.html.slim
+++ b/app/views/shared/_asia_fields.html.slim
@@ -62,9 +62,3 @@
         = f.input :preservation_motor_level_left_id,
         collection: Domain::LevelOfInjury.cached_all,
         label: "Motor Left"
-
-javascript:
-  $(document).ready(function() {
-    showWhenValueEquals("[name='patient[asia_assessment][has_motor_or_sensory_asymmetry]']", "true", "#asymmetry");
-    showWhenValueEquals("[name='patient[asia_assessment][is_complete]']", "true", "#complete");
-  });


### PR DESCRIPTION
fixes #381 

There is an issue with the conditional UI (and probably with saving the form) since we have the same form rendering twice on this page - once for SCI/D tab, and once in ISNCSCI. We should remove one, or find a way to consolidate them. Thoughts @awong-dev @kathytpham ?

![16 register new patient - isncsci formerly asia](https://cloud.githubusercontent.com/assets/1307774/10114042/23e0c94c-63a0-11e5-87d4-8e001b345445.JPG)

gray boxes are conditional
![screen shot 2015-09-25 at 4 11 07 pm](https://cloud.githubusercontent.com/assets/1307774/10114049/41fc15a8-63a0-11e5-95ac-baee5a2e5caf.png)
