### PR TITLE
add deeplink for tabs and fix omr oldness

### DIFF
--- a/app/views/acute_rehabs/_form.html.slim
+++ b/app/views/acute_rehabs/_form.html.slim
@@ -1,4 +1,4 @@
-ul.tabs data-tab="" 
+ul.tabs data-tab="" data-options="deep_linking:true; scroll_to_content: false"
   li.tab-title.active
     a href="#administrative"  Administrative
   li.tab-title

--- a/app/views/annual_evaluations/_form.html.slim
+++ b/app/views/annual_evaluations/_form.html.slim
@@ -1,4 +1,4 @@
-ul.tabs data-tab="" 
+ul.tabs data-tab="" data-options="deep_linking:true; scroll_to_content: false"
   li.tab-title.active
     a href="#administrative"  Administrative
   li.tab-title

--- a/app/views/omrs/_form1year.html.slim
+++ b/app/views/omrs/_form1year.html.slim
@@ -1,19 +1,22 @@
-.form-inputs
-  .callout-blank
-    h4 1 Year OMR
-    .row 
-      .medium-4.columns
-        = f.input :followup_1yr_date, as: :date_picker, label: "Date of 1 Year Follow Up"
+= wrapped_form_for([@patient, @omr]) do |f|
+  = f.error_notification
   .form-inputs
     .callout-blank
       h4 1 Year OMR
       .row 
-        .col-md-4
-          / TODO: Need to add OMR Follow Up Date field
-          p Follow up 1 Year Date: datepicker
+        .medium-4.columns
+          = f.input :followup_1yr_date, as: :date_picker, label: "Date of 1 Year Follow Up"
+    .form-inputs
+      .callout-blank
+        h4 1 Year OMR
+        .row 
+          .col-md-4
+            / TODO: Need to add OMR Follow Up Date field
+            p Follow up 1 Year Date: datepicker
 
-  = f.simple_fields_for :followup_1yr_chart_sf do |chart_sf_builder|
-    = render 'shared/chart_sf_fields', :f => chart_sf_builder
+    = f.simple_fields_for :followup_1yr_chart_sf do |chart_sf_builder|
+      = render 'shared/chart_sf_fields', :f => chart_sf_builder
 
-  = f.simple_fields_for :followup_1yr_sf8 do |sf8_builder|
-    = render 'shared/sf8_fields', :f => sf8_builder
+    = f.simple_fields_for :followup_1yr_sf8 do |sf8_builder|
+      = render 'shared/sf8_fields', :f => sf8_builder
+  = f.submit class:"button large"

--- a/app/views/omrs/_form90day.html.slim
+++ b/app/views/omrs/_form90day.html.slim
@@ -1,16 +1,19 @@
-.form-inputs
-  .callout-blank
-    h4 90 Day OMR
-    .row 
-      .medium-4.columns
-        = f.input :followup_90day_date, as: :date_picker, label: "Date of 90 Day Follow Up"
+= wrapped_form_for([@patient, @omr]) do |f|
+  = f.error_notification
+  .form-inputs
+    .callout-blank
+      h4 90 Day OMR
+      .row 
+        .medium-4.columns
+          = f.input :followup_90day_date, as: :date_picker, label: "Date of 90 Day Follow Up"
 
-  / TODO: Need to add this instrument
-  .instrument 
-    h4 SWLS
+    / TODO: Need to add this instrument
+    .instrument 
+      h4 SWLS
 
-  = f.simple_fields_for :followup_90day_chart_sf do |chart_sf_builder|
-    = render 'shared/chart_sf_fields', :f => chart_sf_builder
+    = f.simple_fields_for :followup_90day_chart_sf do |chart_sf_builder|
+      = render 'shared/chart_sf_fields', :f => chart_sf_builder
 
-  = f.simple_fields_for :followup_90day_sf8 do |sf8_builder|
-    = render 'shared/sf8_fields', :f => sf8_builder
+    = f.simple_fields_for :followup_90day_sf8 do |sf8_builder|
+      = render 'shared/sf8_fields', :f => sf8_builder
+  = f.submit class:"button large"

--- a/app/views/omrs/_formfinish.html.slim
+++ b/app/views/omrs/_formfinish.html.slim
@@ -1,25 +1,28 @@
-.form-inputs
-  .callout-blank
-    h4 Finish OMR
-    .row 
-      .medium-4.columns
-        = f.input :finish_date, as: :date_picker, label: "Date of Completion"
-      .medium-4.columns
-        = f.association :discharge_location,
-        collection: Domain::ResidenceType.cached_all,
-        label_method: :name,
-        value_method: :id,
-        :prompt => "Select one"
+= wrapped_form_for([@patient, @omr]) do |f|
+  = f.error_notification
+  .form-inputs
+    .callout-blank
+      h4 Finish OMR
+      .row 
+        .medium-4.columns
+          = f.input :finish_date, as: :date_picker, label: "Date of Completion"
+        .medium-4.columns
+          = f.association :discharge_location,
+          collection: Domain::ResidenceType.cached_all,
+          label_method: :name,
+          value_method: :id,
+          :prompt => "Select one"
 
-  = f.simple_fields_for :finish_asia do |asia|
-      = render 'shared/asia_fields', :f => asia
+    = f.simple_fields_for :finish_asia do |asia|
+        = render 'shared/asia_fields', :f => asia
 
-  / TODO: Need to add this instrument
-  .instrument 
-    h4 SWLS
+    / TODO: Need to add this instrument
+    .instrument 
+      h4 SWLS
 
-  = f.simple_fields_for :finish_chart_sf do |chart_sf_builder|
-    = render 'shared/chart_sf_fields', :f => chart_sf_builder
+    = f.simple_fields_for :finish_chart_sf do |chart_sf_builder|
+      = render 'shared/chart_sf_fields', :f => chart_sf_builder
 
-  = f.simple_fields_for :finish_sf8 do |sf8_builder|
-    = render 'shared/sf8_fields', :f => sf8_builder
+    = f.simple_fields_for :finish_sf8 do |sf8_builder|
+      = render 'shared/sf8_fields', :f => sf8_builder
+  = f.submit class:"button large"

--- a/app/views/omrs/_formstart.html.slim
+++ b/app/views/omrs/_formstart.html.slim
@@ -1,21 +1,25 @@
-.form-inputs
-  .callout-blank
-    h4 Start OMR
-    .row 
-      .medium-4.columns
-        = f.input :start_date, as: :date_picker, label: "Date of Admission"
-      .medium-4.columns
-        = f.association :start_hub, label: "Name of Hub"
+= wrapped_form_for([@patient, @omr]) do |f|
+  = f.error_notification
+    .data-alert class="alert-box" tabindex="0" aria-live="assertive" role="alertdialog"
+  .form-inputs
+    .callout-blank
+      h4 Start OMR
+      .row 
+        .medium-4.columns
+          = f.input :start_date, as: :date_picker, label: "Date of Admission"
+        .medium-4.columns
+          = f.association :start_hub, label: "Name of Hub"
 
-  = f.simple_fields_for :start_asia do |asia|
-      = render 'shared/asia_fields', :f => asia
+    = f.simple_fields_for :start_asia do |asia|
+        = render 'shared/asia_fields', :f => asia
 
-  / TODO: Need to add this instrument
-  .instrument 
-    h4 SWLS
+    / TODO: Need to add this instrument
+    .instrument 
+      h4 SWLS
 
-  = f.simple_fields_for :start_chart_sf do |chart_sf_builder|
-    = render 'shared/chart_sf_fields', :f => chart_sf_builder
+    = f.simple_fields_for :start_chart_sf do |chart_sf_builder|
+      = render 'shared/chart_sf_fields', :f => chart_sf_builder
 
-  = f.simple_fields_for :start_sf8 do |sf8_builder|
-    = render 'shared/sf8_fields', :f => sf8_builder
+    = f.simple_fields_for :start_sf8 do |sf8_builder|
+      = render 'shared/sf8_fields', :f => sf8_builder
+  = f.submit class:"button large"

--- a/app/views/omrs/_tabigation.slim
+++ b/app/views/omrs/_tabigation.slim
@@ -1,31 +1,32 @@
-.row
-  .panel
-    h3 OMR
-    .panel-body 
-      = wrapped_form_for([@patient, @omr]) do |f|
-        = f.error_notification
-        /! Nav tabs
-        ul.tabs(role="tablist" data-tab)
-          li.tab-title.active role="presentation" 
-            a aria-controls="start" data-toggle="tab" href="#start" role="tab"  Start
-          li.tab-title role="presentation" 
-            a aria-controls="finish" data-toggle="tab" href="#finish" role="tab"  Finish
-          li.tab-title role="presentation" 
-            a aria-controls="ninety-day" data-toggle="tab" href="#ninety-day" role="tab"  90 Day
-          li.tab-title role="presentation" 
-            a aria-controls="one-year" data-toggle="tab" href="#one-year" role="tab"  1 year  
-        /! Tab panes
-        .tabs-content
-          section#start.content.active role="tabpanel"  
-            .callout-blank
-              = render 'formstart', f: f
-          section#finish.content role="tabpanel"  
-            .callout-blank
-              = render 'formfinish', f: f
-          section#ninety-day.content role="tabpanel"  
-            .callout-blank
-              = render 'form90day', f: f
-          section#one-year.content role="tabpanel"  
-            .callout-blank
-              = render 'form1year', f: f
-        = f.submit class:"button large"
+h3 OMR
+ul.tabs data-tab="" data-options="deep_linking:true; scroll_to_content: false"
+  li.tab-title.active
+    a aria-controls="start" data-toggle="tab" href="#start" role="tab"  Start
+  li.tab-title
+    a aria-controls="finish" data-toggle="tab" href="#finish" role="tab"  Finish
+  li.tab-title
+    a aria-controls="ninety-day" data-toggle="tab" href="#ninety-day" role="tab"  90 Day
+  li.tab-title
+    a aria-controls="one-year" data-toggle="tab" href="#one-year" role="tab"  1 year  
+/! Tab panes
+.tabs-content
+  section#start.content.active    
+    .row
+      .panel
+        .panel-body
+          = render 'formstart'
+  section#finish.content
+    .row
+      .panel
+        .panel-body
+          = render 'formfinish'
+  section#ninety-day.content
+    .row
+      .panel
+        .panel-body
+          = render 'form90day'
+  section#one-year.content  
+    .row
+      .panel
+        .panel-body
+          = render 'form1year'

--- a/app/views/patients/edit.html.slim
+++ b/app/views/patients/edit.html.slim
@@ -1,5 +1,5 @@
 h3 Edit patient
-ul.tabs data-tab="" 
+ul.tabs data-tab="" data-options="deep_linking: true; scroll_to_content: false"
   li.tab-title.active
     a href="#history"  History
   li.tab-title

--- a/app/views/patients/new.html.slim
+++ b/app/views/patients/new.html.slim
@@ -1,5 +1,5 @@
 h3 New patient
-ul.tabs data-tab="" 
+ul.tabs data-tab="" data-options="deep_linking:true; scroll_to_content: false"
   li.tab-title.active
     a href="#personal"  Personal Info
   li.tab-title


### PR DESCRIPTION
This looks like a bigger change than it is! 

Added to tabs: data-options="deep_linking:true; scroll_to_content: false"
to make deeplinking work. 

For some reason this adds a "fdtn-tabname" to the tab url. I dislike extra branding, but it feels like a problem for a later day.

Fixes #380 
